### PR TITLE
Fix UB in FieldMap::getField<T>() via zero-copy FieldView<T>

### DIFF
--- a/src/C++/Field.h
+++ b/src/C++/Field.h
@@ -612,62 +612,64 @@ public:
   /// conversion operators on the typed field classes.
   operator value_type() const { return getValue(); }
 
-  /// String comparisons against char* / std::string / std::string_view,
-  /// mirroring the free-function overloads provided for StringField.
-  /// Enabled only when T derives from StringField.
+  /// Backward-compatibility conversion to T so existing client code
+  /// like `const T& x = msg.getField<T>();` keeps compiling. Constructs
+  /// a temporary T, which copies the field string — the zero-copy paths
+  /// (`auto x`, `auto const& x`, `.getValue()`, and the value_type
+  /// conversion operator above) avoid this copy. Prefer those.
+  ///
+  /// This is also the path that reaches the free comparison operators
+  /// on StringField/UtcTimeStampField/etc., so `getField<MsgType>() == "A"`
+  /// continues to work via implicit T construction.
+  [[deprecated(
+      "Binding the result of getField<T>() to `const T&` constructs a temporary T and copies the field "
+      "string. Use `auto` or `auto const&` to keep the zero-copy FieldView<T>, or call .getValue() to read "
+      "the typed value directly.")]]
+  operator T() const {
+    return T(getValue());
+  }
+
+  /// Zero-copy string-equality overloads for StringField-derived T.
+  /// Take priority over the free `operator==(const StringField&, ...)` overloads
+  /// (which would otherwise be reached via the deprecated `operator T()` and
+  /// emit a copy + deprecation warning) because identity-on-LHS beats UDC-on-LHS.
   template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
-  bool operator==(std::string_view rhs) const {
+  bool operator==(const char *rhs) const {
     return m_field.getString() == rhs;
   }
   template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
-  bool operator!=(std::string_view rhs) const {
+  bool operator!=(const char *rhs) const {
     return m_field.getString() != rhs;
   }
   template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
-  bool operator<(std::string_view rhs) const {
-    return m_field.getString() < rhs;
+  bool operator==(const std::string &rhs) const {
+    return m_field.getString() == rhs;
   }
   template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
-  bool operator>(std::string_view rhs) const {
-    return m_field.getString() > rhs;
-  }
-  template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
-  bool operator<=(std::string_view rhs) const {
-    return m_field.getString() <= rhs;
-  }
-  template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
-  bool operator>=(std::string_view rhs) const {
-    return m_field.getString() >= rhs;
+  bool operator!=(const std::string &rhs) const {
+    return m_field.getString() != rhs;
   }
 
 private:
   const FieldBase &m_field;
 };
 
-/// Reversed-operand string comparisons for FieldView<T> where T derives from StringField.
+/// Reversed-operand zero-copy string-equality overloads.
 template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
-inline bool operator==(std::string_view lhs, const FieldView<T> &rhs) {
+inline bool operator==(const char *lhs, const FieldView<T> &rhs) {
   return lhs == rhs.getString();
 }
 template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
-inline bool operator!=(std::string_view lhs, const FieldView<T> &rhs) {
+inline bool operator!=(const char *lhs, const FieldView<T> &rhs) {
   return lhs != rhs.getString();
 }
 template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
-inline bool operator<(std::string_view lhs, const FieldView<T> &rhs) {
-  return lhs < rhs.getString();
+inline bool operator==(const std::string &lhs, const FieldView<T> &rhs) {
+  return lhs == rhs.getString();
 }
 template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
-inline bool operator>(std::string_view lhs, const FieldView<T> &rhs) {
-  return lhs > rhs.getString();
-}
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
-inline bool operator<=(std::string_view lhs, const FieldView<T> &rhs) {
-  return lhs <= rhs.getString();
-}
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
-inline bool operator>=(std::string_view lhs, const FieldView<T> &rhs) {
-  return lhs >= rhs.getString();
+inline bool operator!=(const std::string &lhs, const FieldView<T> &rhs) {
+  return lhs != rhs.getString();
 }
 
 } // namespace FIX

--- a/src/C++/Field.h
+++ b/src/C++/Field.h
@@ -518,6 +518,158 @@ typedef DoubleField PercentageField;
 typedef StringField CountryField;
 typedef StringField TzTimeOnlyField;
 typedef StringField TzTimeStampField;
+
+/**
+ * Zero-copy, type-safe view of a stored FieldBase as a typed field T.
+ *
+ * FieldMap stores fields as plain FieldBase (sliced); a previous version of
+ * FieldMap::getField<T>() reinterpret_cast<>ed a FieldBase* to T*, which is
+ * undefined behaviour. FieldView holds a reference to the actual stored
+ * FieldBase and exposes the same value-access interface as T's parent typed
+ * field class, without ever pretending the underlying object is a T.
+ */
+template <typename T> class FieldView {
+  // Map T to the value type returned by its parent typed field's getValue().
+  // The branches mirror the typed field classes defined above.
+  using value_type = std::conditional_t<
+      std::is_base_of_v<StringField, T>,
+      const std::string &,
+      std::conditional_t<
+          std::is_base_of_v<CharField, T>,
+          char,
+          std::conditional_t<
+              std::is_base_of_v<DoubleField, T>,
+              double,
+              std::conditional_t<
+                  std::is_base_of_v<Int64Field, T>,
+                  int64_t,
+                  std::conditional_t<
+                      std::is_base_of_v<UInt64Field, T>,
+                      uint64_t,
+                      std::conditional_t<
+                          std::is_base_of_v<IntField, T>,
+                          int,
+                          std::conditional_t<
+                              std::is_base_of_v<BoolField, T>,
+                              bool,
+                              std::conditional_t<
+                                  std::is_base_of_v<UtcTimeStampField, T>,
+                                  UtcTimeStamp,
+                                  std::conditional_t<
+                                      std::is_base_of_v<UtcDateField, T>,
+                                      UtcDate,
+                                      std::conditional_t<
+                                          std::is_base_of_v<UtcTimeOnlyField, T>,
+                                          UtcTimeOnly,
+                                          std::conditional_t<std::is_base_of_v<CheckSumField, T>, int, void>>>>>>>>>>>;
+
+  static_assert(!std::is_same_v<value_type, void>, "FieldView<T>: T must derive from a typed field defined in Field.h");
+
+public:
+  explicit FieldView(const FieldBase &field)
+      : m_field(field) {}
+
+  int getTag() const { return m_field.getTag(); }
+  const std::string &getString() const { return m_field.getString(); }
+
+  /// Allows passing the view anywhere a const FieldBase& is expected
+  /// (e.g. setField, operator<<).
+  operator const FieldBase &() const { return m_field; }
+
+  value_type getValue() const EXCEPT(IncorrectDataFormat) {
+    if constexpr (std::is_base_of_v<StringField, T>) {
+      return m_field.getString();
+    } else {
+      try {
+        if constexpr (std::is_base_of_v<CharField, T>) {
+          return CharConvertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<DoubleField, T>) {
+          return DoubleConvertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<Int64Field, T>) {
+          return Int64Convertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<UInt64Field, T>) {
+          return UInt64Convertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<IntField, T>) {
+          return IntConvertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<BoolField, T>) {
+          return BoolConvertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<UtcTimeStampField, T>) {
+          return UtcTimeStampConvertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<UtcDateField, T>) {
+          return UtcDateConvertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<UtcTimeOnlyField, T>) {
+          return UtcTimeOnlyConvertor::convert(m_field.getString());
+        } else if constexpr (std::is_base_of_v<CheckSumField, T>) {
+          return CheckSumConvertor::convert(m_field.getString());
+        }
+      } catch (FieldConvertError &) {
+        throw IncorrectDataFormat(m_field.getTag(), m_field.getString());
+      }
+    }
+  }
+
+  /// Implicit conversion to the underlying value type, mirroring the
+  /// conversion operators on the typed field classes.
+  operator value_type() const { return getValue(); }
+
+  /// String comparisons against char* / std::string / std::string_view,
+  /// mirroring the free-function overloads provided for StringField.
+  /// Enabled only when T derives from StringField.
+  template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
+  bool operator==(std::string_view rhs) const {
+    return m_field.getString() == rhs;
+  }
+  template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
+  bool operator!=(std::string_view rhs) const {
+    return m_field.getString() != rhs;
+  }
+  template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
+  bool operator<(std::string_view rhs) const {
+    return m_field.getString() < rhs;
+  }
+  template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
+  bool operator>(std::string_view rhs) const {
+    return m_field.getString() > rhs;
+  }
+  template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
+  bool operator<=(std::string_view rhs) const {
+    return m_field.getString() <= rhs;
+  }
+  template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<StringField, U>>>
+  bool operator>=(std::string_view rhs) const {
+    return m_field.getString() >= rhs;
+  }
+
+private:
+  const FieldBase &m_field;
+};
+
+/// Reversed-operand string comparisons for FieldView<T> where T derives from StringField.
+template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
+inline bool operator==(std::string_view lhs, const FieldView<T> &rhs) {
+  return lhs == rhs.getString();
+}
+template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
+inline bool operator!=(std::string_view lhs, const FieldView<T> &rhs) {
+  return lhs != rhs.getString();
+}
+template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
+inline bool operator<(std::string_view lhs, const FieldView<T> &rhs) {
+  return lhs < rhs.getString();
+}
+template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
+inline bool operator>(std::string_view lhs, const FieldView<T> &rhs) {
+  return lhs > rhs.getString();
+}
+template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
+inline bool operator<=(std::string_view lhs, const FieldView<T> &rhs) {
+  return lhs <= rhs.getString();
+}
+template <typename T, typename = std::enable_if_t<std::is_base_of_v<StringField, T>>>
+inline bool operator>=(std::string_view lhs, const FieldView<T> &rhs) {
+  return lhs >= rhs.getString();
+}
+
 } // namespace FIX
 
 #define DEFINE_FIELD_CLASS_NUM(NAME, TOK, TYPE, NUM)                                                                   \

--- a/src/C++/FieldMap.h
+++ b/src/C++/FieldMap.h
@@ -142,8 +142,8 @@ public:
   }
 
   /// Get a field without type checking
-  template <typename T> const T &getField() const EXCEPT(FieldNotFound) {
-    return *reinterpret_cast<const T *>(&getFieldRef(T::tag));
+  template <typename T> FieldView<T> getField() const EXCEPT(FieldNotFound) {
+    return FieldView<T>(getFieldRef(T::tag));
   }
 
   template <typename F> std::optional<F> getFieldOptional() const {

--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -372,8 +372,8 @@ void Session::nextResendRequest(const Message &resendRequest, const UtcTimeStamp
 
   Locker l(m_mutex);
 
-  auto beginSeqNo = resendRequest.getField<BeginSeqNo>();
-  auto endSeqNo = resendRequest.getField<EndSeqNo>();
+  SEQNUM beginSeqNo = resendRequest.getField<BeginSeqNo>();
+  SEQNUM endSeqNo = resendRequest.getField<EndSeqNo>();
 
   m_state.onEvent(
       "Received ResendRequest FROM: " + SEQNUM_CONVERTOR::convert(beginSeqNo)
@@ -393,7 +393,7 @@ void Session::nextResendRequest(const Message &resendRequest, const UtcTimeStamp
     }
     generateSequenceReset(beginSeqNo, endSeqNo);
   } else {
-    generateRetransmits(beginSeqNo.getValue(), endSeqNo.getValue());
+    generateRetransmits(beginSeqNo, endSeqNo);
   }
 
   MsgSeqNum msgSeqNum(0);
@@ -718,7 +718,7 @@ void Session::generateLogon(const Message &aLogon) {
   m_state.sentLogon(true);
 }
 
-void Session::generateResendRequest(const BeginString &beginString, const MsgSeqNum &msgSeqNum) {
+void Session::generateResendRequest(const std::string &beginString, SEQNUM msgSeqNum) {
   Message resendRequest = newMessage(MsgType(MsgType_ResendRequest));
 
   BeginSeqNo beginSeqNo((int)getExpectedTargetNum());
@@ -1114,7 +1114,7 @@ bool Session::doTargetTooLow(const Message &msg) {
 
   if (!possDupFlag) {
     std::stringstream stream;
-    stream << "MsgSeqNum too low, expecting " << getExpectedTargetNum() << " but received " << msgSeqNum;
+    stream << "MsgSeqNum too low, expecting " << getExpectedTargetNum() << " but received " << msgSeqNum.getValue();
     generateLogout(stream.str());
     throw std::logic_error(stream.str());
   }

--- a/src/C++/Session.h
+++ b/src/C++/Session.h
@@ -252,8 +252,8 @@ private:
     UtcTimeStamp creationTime = m_state.getCreationTime();
     return m_sessionTime.isInSameRange(now, creationTime);
   }
-  bool isTargetTooHigh(const MsgSeqNum &msgSeqNum) { return msgSeqNum > (m_state.getNextTargetMsgSeqNum()); }
-  bool isTargetTooLow(const MsgSeqNum &msgSeqNum) { return msgSeqNum < (m_state.getNextTargetMsgSeqNum()); }
+  bool isTargetTooHigh(SEQNUM msgSeqNum) { return msgSeqNum > (m_state.getNextTargetMsgSeqNum()); }
+  bool isTargetTooLow(SEQNUM msgSeqNum) { return msgSeqNum < (m_state.getNextTargetMsgSeqNum()); }
   bool isCorrectCompID(const SenderCompID &senderCompID, const TargetCompID &targetCompID) {
     if (!m_checkCompId) {
       return true;
@@ -285,7 +285,7 @@ private:
 
   void generateLogon();
   void generateLogon(const Message &);
-  void generateResendRequest(const BeginString &, const MsgSeqNum &);
+  void generateResendRequest(const std::string &beginString, SEQNUM msgSeqNum);
   void generateSequenceReset(SEQNUM, SEQNUM);
   void generateRetransmits(SEQNUM beginSeqNo, SEQNUM endSeqNo);
   void generateHeartbeat();

--- a/src/at_application.h
+++ b/src/at_application.h
@@ -47,7 +47,7 @@ public:
 
     auto const &clOrdID = message.getField<FIX::ClOrdID>();
 
-    std::pair<FIX::ClOrdID, FIX::SessionID> pair = std::make_pair(clOrdID, sessionID);
+    std::pair<FIX::ClOrdID, FIX::SessionID> pair = std::make_pair(FIX::ClOrdID(clOrdID), sessionID);
 
     if (possResend == true) {
       if (m_orderIDs.find(pair) != m_orderIDs.end()) {


### PR DESCRIPTION
FieldMap stores fields as std::vector<FieldBase> (sliced), but
getField<T>() was doing reinterpret_cast<const T*>(&FieldBase) and
then accessing the object as a T. That is undefined behaviour and
happens to "work" only because the typed field subclasses add no
data members.

Introduce a FieldView<T> wrapper that holds const FieldBase& and
exposes the same value-access surface (getValue(), value-type
conversion, string comparisons for StringField-derived T) without
ever pretending the stored object is a T. getField<T>() now
returns FieldView<T> by value — a single reference; no data is
copied out of storage.

Internal Session helpers that previously took const T& of derived
field types (isTargetTooHigh, isTargetTooLow, generateResendRequest)
now take the underlying value type (SEQNUM / std::string), so they
work uniformly with both FieldView<T> results and dereferenced
FIELD_GET_PTR results.

Note: the FIELD_GET_PTR / FIELD_GET_REF macros in FieldMap.h still
contain the same family of UB via a C-style downcast; this commit
does not touch them. They are exercised independently from
getField<T>() (e.g. in DataDictionary::validate) and can be
addressed in a follow-up.

https://claude.ai/code/session_01E7DLfogLMSmnQSpFycWmob