### PR TITLE
Deprecate FieldMap::getField<T>() and migrate call sites

### DIFF
--- a/src/C++/Acceptor.cpp
+++ b/src/C++/Acceptor.cpp
@@ -105,10 +105,14 @@ Session *Acceptor::getSession(const std::string &msg, Responder &responder) {
   }
 
   try {
-    auto const &beginString = message.getHeader().getField<BeginString>();
-    auto const &clSenderCompID = message.getHeader().getField<SenderCompID>();
-    auto const &clTargetCompID = message.getHeader().getField<TargetCompID>();
-    auto const &msgType = message.getHeader().getField<MsgType>();
+    BeginString beginString;
+    SenderCompID clSenderCompID;
+    TargetCompID clTargetCompID;
+    MsgType msgType;
+    message.getHeader().getField(beginString);
+    message.getHeader().getField(clSenderCompID);
+    message.getHeader().getField(clTargetCompID);
+    message.getHeader().getField(msgType);
     if (msgType != MsgType_Logon) {
       return 0;
     }

--- a/src/C++/FieldMap.h
+++ b/src/C++/FieldMap.h
@@ -142,7 +142,9 @@ public:
   }
 
   /// Get a field without type checking
-  template <typename T> const T &getField() const EXCEPT(FieldNotFound) {
+  template <typename T>
+  [[deprecated("This overload relies on undefined behavior. Use getField(FieldBase&), getFieldRef, or getField(int) instead.")]]
+  const T &getField() const EXCEPT(FieldNotFound) {
     return *reinterpret_cast<const T *>(&getFieldRef(T::tag));
   }
 

--- a/src/C++/Message.cpp
+++ b/src/C++/Message.cpp
@@ -514,9 +514,9 @@ bool Message::isTrailerField(int field, const DataDictionary *pD) {
 
 SessionID Message::getSessionID(const std::string &qualifier) const EXCEPT(FieldNotFound) {
   return SessionID(
-      getHeader().getField<BeginString>(),
-      getHeader().getField<SenderCompID>(),
-      getHeader().getField<TargetCompID>(),
+      getHeader().getField(FIELD::BeginString),
+      getHeader().getField(FIELD::SenderCompID),
+      getHeader().getField(FIELD::TargetCompID),
       qualifier);
 }
 

--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -177,8 +177,8 @@ void Session::next(const UtcTimeStamp &now) {
 }
 
 void Session::nextLogon(const Message &logon, const UtcTimeStamp &now) {
-  logon.getHeader().getField<SenderCompID>();
-  logon.getHeader().getField<TargetCompID>();
+  logon.getHeader().getFieldRef(FIELD::SenderCompID);
+  logon.getHeader().getFieldRef(FIELD::TargetCompID);
 
   if (m_refreshOnLogon) {
     refresh();
@@ -250,7 +250,8 @@ void Session::nextLogon(const Message &logon, const UtcTimeStamp &now) {
   m_state.sentReset(false);
   m_state.receivedReset(false);
 
-  auto const &msgSeqNum = logon.getHeader().getField<MsgSeqNum>();
+  MsgSeqNum msgSeqNum;
+  logon.getHeader().getField(msgSeqNum);
   if (isTargetTooHigh(msgSeqNum) && !resetSeqNumFlag) {
     if (m_sendNextExpectedMsgSeqNum) {
       m_state.onEvent(
@@ -372,8 +373,10 @@ void Session::nextResendRequest(const Message &resendRequest, const UtcTimeStamp
 
   Locker l(m_mutex);
 
-  auto beginSeqNo = resendRequest.getField<BeginSeqNo>();
-  auto endSeqNo = resendRequest.getField<EndSeqNo>();
+  BeginSeqNo beginSeqNo;
+  EndSeqNo endSeqNo;
+  resendRequest.getField(beginSeqNo);
+  resendRequest.getField(endSeqNo);
 
   m_state.onEvent(
       "Received ResendRequest FROM: " + SEQNUM_CONVERTOR::convert(beginSeqNo)
@@ -648,8 +651,9 @@ void Session::disconnect() {
 
 bool Session::resend(Message &message) {
   Header &header = message.getHeader();
-  auto const &sendingTime = header.getField<SendingTime>();
-  header.getField<MsgSeqNum>();
+  SendingTime sendingTime;
+  header.getField(sendingTime);
+  header.getFieldRef(FIELD::MsgSeqNum);
   insertOrigSendingTime(header, sendingTime);
   header.setField(PossDupFlag(true));
   insertSendingTime(header);
@@ -663,7 +667,8 @@ bool Session::resend(Message &message) {
 }
 
 void Session::persist(const Message &message, const std::string &messageString) EXCEPT(IOException) {
-  auto const &msgSeqNum = message.getHeader().getField<MsgSeqNum>();
+  MsgSeqNum msgSeqNum;
+  message.getHeader().getField(msgSeqNum);
   if (m_persistMessages) {
     m_state.set(msgSeqNum, messageString);
   }
@@ -708,7 +713,7 @@ void Session::generateLogon(const Message &aLogon) {
   if (m_state.receivedReset()) {
     logon.setField(ResetSeqNumFlag(true));
   }
-  logon.setField(aLogon.getField<HeartBtInt>());
+  logon.setField(aLogon.getFieldRef(FIELD::HeartBtInt));
   if (m_sendNextExpectedMsgSeqNum) {
     logon.setField(NextExpectedMsgSeqNum(
         getExpectedTargetNum() + 1)); // +1 because incoming Logon did not increment the target SeqNum yet
@@ -748,7 +753,9 @@ void Session::generateSequenceReset(SEQNUM beginSeqNo, SEQNUM endSeqNo) {
   sequenceReset.setField(newSeqNo);
   fill(sequenceReset.getHeader());
 
-  insertOrigSendingTime(sequenceReset.getHeader(), sequenceReset.getHeader().getField<SendingTime>());
+  SendingTime sendingTime;
+  sequenceReset.getHeader().getField(sendingTime);
+  insertOrigSendingTime(sequenceReset.getHeader(), sendingTime);
   sequenceReset.getHeader().setField(MsgSeqNum(beginSeqNo));
   sequenceReset.setField(GapFillFlag(true));
   sendRaw(sequenceReset, beginSeqNo);
@@ -767,7 +774,7 @@ void Session::generateHeartbeat(const Message &testRequest) {
 
   fill(heartbeat.getHeader());
   try {
-    heartbeat.setField(testRequest.getField<TestReqID>());
+    heartbeat.setField(testRequest.getFieldRef(FIELD::TestReqID));
   } catch (FieldNotFound &) {}
 
   sendRaw(heartbeat);
@@ -793,7 +800,8 @@ void Session::generateReject(const Message &message, int err, int field) {
 
   MsgSeqNum msgSeqNum;
 
-  auto const &msgType = message.getHeader().getField<MsgType>();
+  MsgType msgType;
+  message.getHeader().getField(msgType);
   if (message.getHeader().getFieldIfSet(msgSeqNum)) {
     if (msgSeqNum.getString() != "") {
       reject.setField(RefSeqNum(msgSeqNum));
@@ -879,8 +887,10 @@ void Session::generateReject(const Message &message, const std::string &text) {
   reject.reverseRoute(message.getHeader());
   fill(reject.getHeader());
 
-  auto const &msgType = message.getHeader().getField<MsgType>();
-  auto const &msgSeqNum = message.getHeader().getField<MsgSeqNum>();
+  MsgType msgType;
+  MsgSeqNum msgSeqNum;
+  message.getHeader().getField(msgType);
+  message.getHeader().getField(msgSeqNum);
 
   if (beginString >= FIX::BeginString_FIX42) {
     reject.setField(RefMsgType(msgType));
@@ -898,13 +908,14 @@ void Session::generateReject(const Message &message, const std::string &text) {
 
 void Session::generateBusinessReject(const Message &message, int err, int field) {
   Message reject = newMessage(MsgType(MsgType_BusinessMessageReject));
-  auto const &msgSeqNum = message.getHeader().getField<MsgSeqNum>();
+  MsgSeqNum msgSeqNum;
+  message.getHeader().getField(msgSeqNum);
 
   if (m_sessionID.isFIXT()) {
     reject.setField(DefaultApplVerID(m_senderDefaultApplVerID));
   }
   fill(reject.getHeader());
-  reject.setField(RefMsgType(message.getHeader().getField<MsgType>()));
+  reject.setField(RefMsgType(message.getHeader().getField(FIELD::MsgType)));
   reject.setField(RefSeqNum(msgSeqNum));
   reject.setField(BusinessRejectReason(err));
   m_state.incrNextTargetMsgSeqNum();
@@ -963,7 +974,8 @@ void Session::generateLogout(const std::string &text) {
 }
 
 void Session::populateRejectReason(Message &reject, int field, const std::string &text) {
-  auto const &msgType = reject.getHeader().getField<MsgType>();
+  MsgType msgType;
+  reject.getHeader().getField(msgType);
 
   if (msgType == MsgType_Reject && m_sessionID.getBeginString() >= FIX::BeginString_FIX42) {
     reject.setField(RefTagID(field));
@@ -1088,8 +1100,10 @@ bool Session::doPossDup(const Message &msg) {
   OrigSendingTime origSendingTime = m_timestamper();
 
   const Header &header = msg.getHeader();
-  auto const &msgType = header.getField<MsgType>();
-  auto const &sendingTime = header.getField<SendingTime>();
+  MsgType msgType;
+  SendingTime sendingTime;
+  header.getField(msgType);
+  header.getField(sendingTime);
 
   if (msgType != MsgType_SequenceReset) {
     if (!header.getFieldIfSet(origSendingTime)) {
@@ -1110,7 +1124,8 @@ bool Session::doTargetTooLow(const Message &msg) {
   const Header &header = msg.getHeader();
   PossDupFlag possDupFlag(false);
   header.getFieldIfSet(possDupFlag);
-  auto const &msgSeqNum = header.getField<MsgSeqNum>();
+  MsgSeqNum msgSeqNum;
+  header.getField(msgSeqNum);
 
   if (!possDupFlag) {
     std::stringstream stream;
@@ -1124,8 +1139,10 @@ bool Session::doTargetTooLow(const Message &msg) {
 
 void Session::doTargetTooHigh(const Message &msg) {
   const Header &header = msg.getHeader();
-  auto const &beginString = header.getField<BeginString>();
-  auto const &msgSeqNum = header.getField<MsgSeqNum>();
+  BeginString beginString;
+  MsgSeqNum msgSeqNum;
+  header.getField(beginString);
+  header.getField(msgSeqNum);
 
   m_state.onEvent(
       "MsgSeqNum too high, expecting " + SEQNUM_CONVERTOR::convert(getExpectedTargetNum()) + " but received "
@@ -1156,7 +1173,8 @@ bool Session::nextQueued(SEQNUM num, const UtcTimeStamp &now) {
 
   if (m_state.retrieve(num, msg)) {
     m_state.onEvent("Processing QUEUED message: " + SEQNUM_CONVERTOR::convert(num));
-    auto const &msgType = msg.getHeader().getField<MsgType>();
+    MsgType msgType;
+    msg.getHeader().getField(msgType);
     if (msgType == MsgType_Logon || msgType == MsgType_ResendRequest) {
       m_state.incrNextTargetMsgSeqNum();
     } else {

--- a/src/C++/test/SessionTestCase.cpp
+++ b/src/C++/test/SessionTestCase.cpp
@@ -2397,7 +2397,9 @@ TEST_CASE_METHOD(acceptorT11Fixture, "AcceptorT11TestCase") {
     FIXT11::Logon logon = createT11Logon("ISLD", "TW", 1);
     logon.set(NextExpectedMsgSeqNum(1));
     object->next(logon, now);
-    CHECK(2 == sentLogon.getField<NextExpectedMsgSeqNum>());
+    NextExpectedMsgSeqNum nextExpectedMsgSeqNum;
+    sentLogon.getField(nextExpectedMsgSeqNum);
+    CHECK(2 == nextExpectedMsgSeqNum);
 
     object->next(createT11Heartbeat("ISLD", "TW", 2), now);
     FIX::Message heartbeat = createT11Heartbeat("TW", "ISLD", 2);
@@ -2412,8 +2414,11 @@ TEST_CASE_METHOD(acceptorT11Fixture, "AcceptorT11TestCase") {
     logon.set(NextExpectedMsgSeqNum(1));      // initiator pretends to miss SeqNum 2 and 3
     object->next(logon, now);
 
-    CHECK(6 == sentLogon.getField<NextExpectedMsgSeqNum>());
-    CHECK(3 == lastResent.getHeader().getField<MsgSeqNum>().getValue()); // retransmitted ExecutionReport
+    sentLogon.getField(nextExpectedMsgSeqNum);
+    CHECK(6 == nextExpectedMsgSeqNum);
+    MsgSeqNum msgSeqNum;
+    lastResent.getHeader().getField(msgSeqNum);
+    CHECK(3 == msgSeqNum.getValue()); // retransmitted ExecutionReport
     CHECK(2 == toSequenceReset);
 
     CHECK(0 == toResendRequest); // no resend request for SeqNum 5-9, initiator is expected to start message recovery
@@ -2437,7 +2442,9 @@ TEST_CASE_METHOD(initiatorT11Fixture, "InitiatorT11TestCase") {
     object->setResponder(this);
 
     object->next(now);
-    CHECK(1 == sentLogon.getField<NextExpectedMsgSeqNum>());
+    NextExpectedMsgSeqNum nextExpectedMsgSeqNum;
+    sentLogon.getField(nextExpectedMsgSeqNum);
+    CHECK(1 == nextExpectedMsgSeqNum);
 
     FIXT11::Logon logon = createT11Logon("ISLD", "TW", 1);
     logon.set(NextExpectedMsgSeqNum(2));
@@ -2453,12 +2460,15 @@ TEST_CASE_METHOD(initiatorT11Fixture, "InitiatorT11TestCase") {
     object->next(createT11Logout("ISLD", "TW", 4), now);
 
     object->next(now);
-    CHECK(5 == sentLogon.getField<NextExpectedMsgSeqNum>());
+    sentLogon.getField(nextExpectedMsgSeqNum);
+    CHECK(5 == nextExpectedMsgSeqNum);
     logon = createT11Logon("ISLD", "TW", 10); // acceptor pretends to have sent SeqNum 5-9 before
     logon.set(NextExpectedMsgSeqNum(2));      // acceptor pretends to miss SeqNum 2 and 3
     object->next(logon, now);
 
-    CHECK(3 == lastResent.getHeader().getField<MsgSeqNum>().getValue()); // retransmitted NewOrderSingle
+    MsgSeqNum msgSeqNum;
+    lastResent.getHeader().getField(msgSeqNum);
+    CHECK(3 == msgSeqNum.getValue()); // retransmitted NewOrderSingle
     CHECK(2 == toSequenceReset);
 
     CHECK(0 == toResendRequest); // no resend request for SeqNum 5-9, acceptor is expected to start message recovery

--- a/src/at_application.h
+++ b/src/at_application.h
@@ -45,7 +45,8 @@ public:
     FIX::PossResend possResend(false);
     message.getHeader().getFieldIfSet(possResend);
 
-    auto const &clOrdID = message.getField<FIX::ClOrdID>();
+    FIX::ClOrdID clOrdID;
+    message.getField(clOrdID);
 
     std::pair<FIX::ClOrdID, FIX::SessionID> pair = std::make_pair(clOrdID, sessionID);
 
@@ -140,10 +141,12 @@ class Application : public FIX::Application {
 
   void fromAdmin(const FIX::Message &message, const FIX::SessionID &sessionID)
       EXCEPT(FIX::FieldNotFound, FIX::IncorrectDataFormat, FIX::IncorrectTagValue, FIX::RejectLogon) {
-    auto const &msgType = message.getHeader().getField<FIX::MsgType>();
+    FIX::MsgType msgType;
+    message.getHeader().getField(msgType);
     if (msgType == FIX::MsgType_Logon) {
       if (message.isSetField(FIX::FIELD::DefaultApplVerID)) {
-        auto const &defaultApplVerID = message.getField<FIX::DefaultApplVerID>();
+        FIX::DefaultApplVerID defaultApplVerID;
+        message.getField(defaultApplVerID);
         FIX::Session::lookupSession(sessionID)->setSenderDefaultApplVerID(defaultApplVerID);
       }
     }
@@ -151,7 +154,8 @@ class Application : public FIX::Application {
 
   void fromApp(const FIX::Message &message, const FIX::SessionID &sessionID)
       EXCEPT(FIX::FieldNotFound, FIX::IncorrectDataFormat, FIX::IncorrectTagValue, FIX::UnsupportedMessageType) {
-    auto const &msgType = message.getHeader().getField<FIX::MsgType>();
+    FIX::MsgType msgType;
+    message.getHeader().getField(msgType);
     if (msgType == FIX::MsgType_Email) {
       FIX::Message echo = message;
       FIX::Session::sendToTarget(echo, sessionID);


### PR DESCRIPTION
The template overload uses reinterpret_cast to view a FieldBase object as
a derived typed-field, which is undefined behavior. Mark it deprecated
and switch every internal call site to a safe alternative: getField(FieldBase&)
for typed access, getFieldRef for existence checks or untyped use,
or getField(int) when only the raw string is needed.