### PR TITLE
Require C++17 as minimum standard instead of C++11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,9 +38,7 @@ AX_RUBY()
 
 AC_CANONICAL_HOST
 
-AX_CXX_COMPILE_STDCXX( [11], [noext], mandatory)
-AX_CXX_COMPILE_STDCXX( [14], [noext], optional)
-AX_CXX_COMPILE_STDCXX( [17], [noext], optional)
+AX_CXX_COMPILE_STDCXX( [17], [noext], mandatory)
 
 ########################################
 # TBB


### PR DESCRIPTION
## Summary
Updated the C++ standard requirements in the build configuration to make C++17 the mandatory minimum standard, removing support for C++11 and C++14.

## Key Changes
- Changed C++17 from optional to mandatory in the build configuration
- Removed C++11 as the base mandatory standard
- Removed C++14 as an optional standard
- This simplifies the build configuration by establishing a single, modern C++ standard requirement

## Details
The configure.ac file previously required C++11 as mandatory and offered optional support for C++14 and C++17. This change consolidates the requirement to C++17 only, eliminating the need to maintain backward compatibility with older C++ standards. This allows the codebase to leverage C++17 features without conditional compilation or compatibility workarounds.

https://claude.ai/code/session_019KcQmn1bHkYdqKnxX13cjd