### PR TITLE
Replace C-style headers with C++ standard library headers

### DIFF
--- a/src/C++/DataDictionary.h
+++ b/src/C++/DataDictionary.h
@@ -30,9 +30,9 @@
 #include "Exceptions.h"
 #include "FieldMap.h"
 #include "Fields.h"
+#include <cstring>
 #include <map>
 #include <set>
-#include <cstring>
 
 namespace FIX {
 class FieldMap;

--- a/src/C++/DataDictionary.h
+++ b/src/C++/DataDictionary.h
@@ -32,7 +32,7 @@
 #include "Fields.h"
 #include <map>
 #include <set>
-#include <string.h>
+#include <cstring>
 
 namespace FIX {
 class FieldMap;

--- a/src/C++/Event.h
+++ b/src/C++/Event.h
@@ -23,10 +23,9 @@
 #define FIX_EVENT_H
 
 #include "Utility.h"
-#include <math.h>
+#include <cmath>
 
 #ifndef _MSC_VER
-#include <cmath>
 #include <pthread.h>
 #endif
 

--- a/src/C++/FieldConvertors.cpp
+++ b/src/C++/FieldConvertors.cpp
@@ -24,7 +24,7 @@
 #endif
 
 #include "FieldConvertors.h"
-#include <math.h>
+#include <cmath>
 
 namespace FIX {
 

--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -26,7 +26,7 @@
 #include "FieldTypes.h"
 #include "Utility.h"
 #include "config-all.h"
-#include <assert.h>
+#include <cassert>
 #include <cstdio>
 #include <iomanip>
 #include <iterator>

--- a/src/C++/FieldTypes.h
+++ b/src/C++/FieldTypes.h
@@ -27,11 +27,11 @@
 #pragma warning(disable : 4503 4355 4786 4290)
 #endif
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "Utility.h"
 #include <string>
-#include <time.h>
+#include <ctime>
 
 #include <chrono>
 

--- a/src/C++/FieldTypes.h
+++ b/src/C++/FieldTypes.h
@@ -30,8 +30,8 @@
 #include <cstdint>
 
 #include "Utility.h"
-#include <string>
 #include <ctime>
+#include <string>
 
 #include <chrono>
 

--- a/src/C++/HostDetailsProvider.h
+++ b/src/C++/HostDetailsProvider.h
@@ -5,7 +5,7 @@
 #include <map>
 #include <optional>
 #include <string>
-#include <time.h>
+#include <ctime>
 
 namespace FIX {
 class Dictionary;

--- a/src/C++/HostDetailsProvider.h
+++ b/src/C++/HostDetailsProvider.h
@@ -1,11 +1,11 @@
 #ifndef FIX_HOSTDETAILSPROVIDER_H
 #define FIX_HOSTDETAILSPROVIDER_H
 
+#include <ctime>
 #include <functional>
 #include <map>
 #include <optional>
 #include <string>
-#include <ctime>
 
 namespace FIX {
 class Dictionary;

--- a/src/C++/HttpConnection.h
+++ b/src/C++/HttpConnection.h
@@ -27,7 +27,7 @@
 #endif
 
 #include "HttpParser.h"
-#include <stdio.h>
+#include <cstdio>
 
 namespace FIX {
 class HttpMessage;

--- a/src/C++/Message.cpp
+++ b/src/C++/Message.cpp
@@ -227,7 +227,9 @@ std::string &Message::toString(std::string &str, int beginStringField, int bodyL
     return sum;
   };
   int bodyLengthFieldContrib = sumAsciiDigits(bodyLengthField) + '=' + sumAsciiDigits(bodyLength) + '\001';
-  int totalChecksum = (headerLengthAndTotal.total + bodyLengthAndTotal.total + trailerLengthAndTotal.total + bodyLengthFieldContrib) % 256;
+  int totalChecksum
+      = (headerLengthAndTotal.total + bodyLengthAndTotal.total + trailerLengthAndTotal.total + bodyLengthFieldContrib)
+        % 256;
 
   m_header.setField(IntField(bodyLengthField, bodyLength));
   m_trailer.setField(CheckSumField(checkSumField, totalChecksum));

--- a/src/C++/MessageSorters.cpp
+++ b/src/C++/MessageSorters.cpp
@@ -25,7 +25,7 @@
 
 #include "MessageSorters.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace FIX {
 message_order::message_order(int first, ...)

--- a/src/C++/Utility.cpp
+++ b/src/C++/Utility.cpp
@@ -30,13 +30,13 @@
 #include <sys/conf.h>
 #endif
 #include <algorithm>
-#include <cstdarg>
-#include <fstream>
-#include <iostream>
 #include <cmath>
-#include <sstream>
+#include <cstdarg>
 #include <cstdio>
 #include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 
 namespace FIX {
 std::string error_strerror(decltype(errno) error_number) {

--- a/src/C++/Utility.cpp
+++ b/src/C++/Utility.cpp
@@ -33,10 +33,10 @@
 #include <cstdarg>
 #include <fstream>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <sstream>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 namespace FIX {
 std::string error_strerror(decltype(errno) error_number) {

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -71,9 +71,9 @@
 #ifdef _MSC_VER
 /////////////////////////////////////////////
 #include <Winsock2.h>
+#include <ctime>
 #include <direct.h>
 #include <process.h>
-#include <ctime>
 #define INVALID_SOCKET_HANDLE INVALID_SOCKET
 #define BIND_SOCKET_ERROR SOCKET_ERROR
 #define LISTEN_SOCKET_ERROR SOCKET_ERROR
@@ -83,19 +83,19 @@
 /////////////////////////////////////////////
 #include <arpa/inet.h>
 #include <cerrno>
+#include <csignal>
+#include <cstdlib>
+#include <ctime>
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <pthread.h>
-#include <csignal>
-#include <cstdlib>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <ctime>
 #include <unistd.h>
 #define INVALID_SOCKET_HANDLE -1
 #define BIND_SOCKET_ERROR -1

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -73,7 +73,7 @@
 #include <Winsock2.h>
 #include <direct.h>
 #include <process.h>
-#include <time.h>
+#include <ctime>
 #define INVALID_SOCKET_HANDLE INVALID_SOCKET
 #define BIND_SOCKET_ERROR SOCKET_ERROR
 #define LISTEN_SOCKET_ERROR SOCKET_ERROR
@@ -82,20 +82,20 @@
 #else
 /////////////////////////////////////////////
 #include <arpa/inet.h>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <pthread.h>
-#include <signal.h>
-#include <stdlib.h>
+#include <csignal>
+#include <cstdlib>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <time.h>
+#include <ctime>
 #include <unistd.h>
 #define INVALID_SOCKET_HANDLE -1
 #define BIND_SOCKET_ERROR -1

--- a/src/C++/stdafx.h
+++ b/src/C++/stdafx.h
@@ -13,7 +13,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 
 #include "config.h"
-#include <stdio.h>
+#include <cstdio>
 
 #define TERMINATE_IN_STD 1
 

--- a/src/C++/test/MessageStoreTestCase.h
+++ b/src/C++/test/MessageStoreTestCase.h
@@ -24,7 +24,7 @@
 #include <fix42/Logon.h>
 #include <fix42/NewOrderSingle.h>
 
-#include <limits.h>
+#include <climits>
 
 #define CHECK_MESSAGE_STORE_SET_GET                                                                                    \
   FIX42::Logon logon;                                                                                                  \

--- a/src/C++/test/SocketConnectorTestCase.cpp
+++ b/src/C++/test/SocketConnectorTestCase.cpp
@@ -28,7 +28,7 @@
 #include <SocketConnector.h>
 #include <SocketServer.h>
 #ifdef _MSC_VER
-#include <stdlib.h>
+#include <cstdlib>
 #endif
 
 #include "catch_amalgamated.hpp"

--- a/src/C++/test/SocketServerTestCase.cpp
+++ b/src/C++/test/SocketServerTestCase.cpp
@@ -27,7 +27,7 @@
 #include "TestHelper.h"
 #include <SocketServer.h>
 #ifdef _MSC_VER
-#include <stdlib.h>
+#include <cstdlib>
 #endif
 
 #include "catch_amalgamated.hpp"

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -13,7 +13,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 
 #include "config.h"
-#include <stdio.h>
+#include <cstdio>
 
 // TODO: reference additional headers your program requires here
 

--- a/test/atrun/main.cpp
+++ b/test/atrun/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <signal.h>
+#include <csignal>
 #include <string>
 
 #include "Process.h"


### PR DESCRIPTION
## Summary
This pull request modernizes the codebase by replacing deprecated C-style headers with their C++ standard library equivalents throughout the project. This change improves standards compliance and code quality.

## Key Changes
- Replaced C headers with C++ equivalents:
  - `<time.h>` → `<ctime>`
  - `<errno.h>` → `<cerrno>`
  - `<signal.h>` → `<csignal>`
  - `<stdlib.h>` → `<cstdlib>`
  - `<math.h>` → `<cmath>`
  - `<stdio.h>` → `<cstdio>`
  - `<string.h>` → `<cstring>`
  - `<stdint.h>` → `<cstdint>`
  - `<assert.h>` → `<cassert>`
  - `<limits.h>` → `<climits>`

- Updated headers across multiple files:
  - Core utility headers (Utility.h, Utility.cpp)
  - Field-related headers (FieldTypes.h, FieldConvertors.h/cpp)
  - Connection and message handling (Event.h, HttpConnection.h, DataDictionary.h, MessageSorters.cpp)
  - Test files and precompiled headers (stdafx.h, test cases)
  - Application entry points (test/atrun/main.cpp)

## Implementation Details
- Removed redundant `#include <cmath>` from Event.h (was included twice for non-MSVC builds)
- All replacements maintain functional equivalence while adhering to modern C++ standards
- Changes are backward compatible and improve code portability

https://claude.ai/code/session_01AzTq3WWHkbnbMVWVwnXdmH